### PR TITLE
.travis.yml: try installing on a build agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: objective-c # but not really
+script: ./bootstrap.sh


### PR DESCRIPTION
This is a first cut at getting this under CI.

However, [babushka](http://babushka.me/) (still) stalls when it thinks there is a console attached. Since the force-install option has long since been deprecated, perhaps its time to investigate a new tool.

Don't merge until we sort that out...
